### PR TITLE
ntjoin_assemble.py: Fix off-by-one error with output scaffolds

### DIFF
--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -481,9 +481,9 @@ class Ntjoin:
     def get_fasta_segment(path_node, sequence):
         "Given a PathNode and the contig sequence, return the corresponding sequence"
         if path_node.ori == "-":
-            return Ntjoin.reverse_complement(sequence[path_node.start:path_node.end+1]) + \
+            return Ntjoin.reverse_complement(sequence[path_node.start:path_node.end]) + \
                    "N"*path_node.gap_size
-        return sequence[path_node.start:path_node.end+1] + "N"*path_node.gap_size
+        return sequence[path_node.start:path_node.end] + "N"*path_node.gap_size
 
     @staticmethod
     def format_bedtools_genome(scaffolds):


### PR DESCRIPTION
* Coordinates are in BED format already, ie. they do go one past the included base