### PR TITLE
ntjoin_assemble.py: Bugfix to linear path function

### DIFF
--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -405,7 +405,7 @@ class Ntjoin:
         "Given a graph, return True if all the components are linear"
         for component in graph.components():
             component_graph = graph.subgraph(component)
-            if not all(u.degree() < 2 for u in component_graph.vs()):
+            if not all(u.degree() < 3 for u in component_graph.vs()):
                 return False
         return True
 


### PR DESCRIPTION
* Bug meant that components that were linear, with all nodes having degree <= 2 would be considered non-linear by the function "is_graph_linear"
* The bug didn't impact the resulting scaffolds, as edges will only be filtered incident to branch nodes (degree >2)
* It just meant that the for-loop that iterates until either the max_edge_weight is reached or the graph is linear may have executed more times than necessary