### PR TITLE
Fix for edge cases that could duplicate sequence

### DIFF
--- a/bin/.pylintrc
+++ b/bin/.pylintrc
@@ -4,11 +4,12 @@ max-locals = 50
 max-args = 10
 max-attributes = 10
 max-line-length = 120
-max-branches = 15
+max-branches = 20 
 max-public-methods=50
 max-statements = 60 
 max-module-lines = 1500
-
+max-bool-expr = 7
+ 
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.

--- a/bin/.pylintrc
+++ b/bin/.pylintrc
@@ -6,7 +6,7 @@ max-attributes = 10
 max-line-length = 120
 max-branches = 15
 max-public-methods=50
-max-statements = 55
+max-statements = 60 
 
 [MISCELLANEOUS]
 

--- a/bin/.pylintrc
+++ b/bin/.pylintrc
@@ -7,6 +7,7 @@ max-line-length = 120
 max-branches = 15
 max-public-methods=50
 max-statements = 60 
+max-module-lines = 1500
 
 [MISCELLANEOUS]
 

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -574,7 +574,12 @@ class Ntjoin:
                 paths_return.append(path)
                 self.tally_incorporated_segments(incorporated_segments, path)
 
-        return paths_return, incorporated_segments
+        paths_return_merged = []
+        for path in paths_return:
+            path = self.merge_relocations(path, incorporated_segments)
+            paths_return_merged.append(path)
+
+        return paths_return_merged, incorporated_segments
 
 
     @staticmethod

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -103,8 +103,8 @@ class OverlapRegion:
         # Double check if any still overlap. If so, adjust smaller of the regions.
         sorted_regions = sorted([(b, a) for b, a in return_regions.items() if a is not None], key=lambda x: x[1])
         i, j = 0, 1
-        print(sorted_regions[0].contig, sorted_regions)
-        while j < len(sorted_regions)-1:
+        print(sorted_regions[0][0], sorted_regions)
+        while j < len(sorted_regions):
         #for i in range(0, len(sorted_regions)-1):
             region1_before, region2_before = sorted_regions[i][0], sorted_regions[j][0]
             region1_after, region2_after = sorted_regions[i][1], sorted_regions[j][1]

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -411,6 +411,7 @@ class Ntjoin:
                         continue
                     return_path[-1].end = node_j.end
                     return_path[-1].terminal_mx = node_j.terminal_mx
+                    return_path[-1].gap_size = node_j.gap_size
                     Ntjoin.incorporated_segments[node_i.contig].append(Bed(contig=node_i.contig,
                                                                            start=node_i.start,
                                                                            end=node_j.end))
@@ -423,6 +424,7 @@ class Ntjoin:
                         continue
                     return_path[-1].start = node_j.start
                     return_path[-1].first_mx = node_j.first_mx
+                    return_path[-1].gap_size = node_j.gap_size
                     Ntjoin.incorporated_segments[node_i.contig].append(Bed(contig=node_i.contig,
                                                                            start=node_j.start,
                                                                            end=node_i.end))

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -547,6 +547,8 @@ class Ntjoin:
     @staticmethod
     def tally_incorporated_segments(incorporated_list, path):
         "Keep track of extents incorporated into path"
+        if len(path) < 2:
+            return
         for path_node in path:
             if path_node.contig not in incorporated_list:
                 incorporated_list[path_node.contig] = []

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -837,7 +837,7 @@ class Ntjoin:
             for bed_entry in incorporated_segments[ctg]:
                 incorporated_bed_list.append(bed_entry)
         incorporated_bed_str = "\n".join(["%s\t%s\t%s" % (chrom, s, e)
-                                          for chrom, s, e in incorporated_segments])
+                                          for chrom, s, e in incorporated_bed_list])
         incorporated_segments_bed = pybedtools.BedTool(incorporated_bed_str,
                                                        from_string=True).sort()
         bed_intersect = incorporated_segments_bed.intersect(b=incorporated_segments_bed,

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -298,7 +298,8 @@ class Ntjoin:
             gap_size = min(gap_size, self.args.G)
         return gap_size
 
-    def is_new_region_overlapping(self, start, end, incorporated_segments_ctg):
+    @staticmethod
+    def is_new_region_overlapping(start, end, incorporated_segments_ctg):
         "Checks if the specified region overlaps any existing regions in incorporated segments"
         for segment in incorporated_segments_ctg:
             if start <= segment.end and segment.start <= end:
@@ -464,7 +465,7 @@ class Ntjoin:
         for path_node in path:
             if path_node.contig not in incorporated_list:
                 incorporated_list[path_node.contig] = []
-            incorporated_list.append(Bed(contig=path_node.contig,
+            incorporated_list[path_node.contig].append(Bed(contig=path_node.contig,
                                          start=path_node.start,
                                          end=path_node.end))
 
@@ -942,7 +943,7 @@ class Ntjoin:
             paths = self.adjust_paths(paths, scaffolds, incorporated_segments)
 
         # Print the final scaffolds
-        self.print_scaffolds(paths)
+        self.print_scaffolds(paths, incorporated_segments)
 
         print(datetime.datetime.today(), ": DONE!", file=sys.stdout)
 

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -115,10 +115,12 @@ class OverlapRegion:
                     return_regions[region2_before] = None
                 elif (region1_after.end - region1_after.start) > (region2_after.end - region2_after.start):
                     # Adjust region 2 start
-                    return_regions[region2_before].start = region1_after.end + 1
+                    return_regions[region2_before] = Bed(contig=region2_after.contig, start=region1_after.end + 1,
+                                                         end=region2_after.end)
                 elif (region1_after.end - region1_after.start) <= (region2_after.end - region2_after.start):
                     # Adjust region 1 end
-                    return_regions[region1_before].end = region2_after.start - 1
+                    return_regions[region1_before] = Bed(contig=region1_after.contig, start=region1_after.start,
+                                                         end=region2_after.start - 1)
 
             i += 1
 

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -796,12 +796,13 @@ class Ntjoin:
         for path_node in path:
             if path_node.contig in intersecting_regions:
                 node_bed = Bed(contig=path_node.contig, start=path_node.start, end=path_node.end)
-                new_bed = intersecting_regions[path_node.contig][node_bed]
-                if new_bed is None:
-                    continue
-                if new_bed != node_bed:
-                    path_node.start = new_bed.start
-                    path_node.end = new_bed.end
+                if node_bed in intersecting_regions[path_node.contig]:
+                    new_bed = intersecting_regions[path_node.contig][node_bed]
+                    if new_bed is None:
+                        continue
+                    if new_bed != node_bed:
+                        path_node.start = new_bed.start
+                        path_node.end = new_bed.end
             new_path.append(path_node)
 
         return new_path

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -61,15 +61,15 @@ class OverlapRegion:
     def add_region(self, bed_region):
         "Add a new region to the overlapping set"
         if self.best_region is None or \
-                                bed_region.end - bed_region.start > \
-                                self.best_region.end - self.best_region.start:
+                        (bed_region.end - bed_region.start) > \
+                        (self.best_region.end - self.best_region.start):
             self.best_region = bed_region
         self.regions.append(bed_region)
         assert bed_region.contig == self.best_region.contig
 
     @staticmethod
     def are_overlapping(region1, region2):
-        "Returns 2 if the given regions are overlapping"
+        "Returns True if the given regions are overlapping"
         return region1.start <= region2.end and region2.start <= region1.end
 
     @staticmethod
@@ -78,15 +78,15 @@ class OverlapRegion:
         return region1.start >= region2.start and region1.end <= region2.end
 
     def find_non_overlapping(self):
-        "Given overlapping regions, resolve so no overlap"
-        return_regions = {} # Bed -> replacement Bed or None
+        "Given overlapping regions, resolve to remove overlaps"
+        return_regions = {} # Bed -> (replacement Bed) or None
         if not self.regions or self.best_region is None:
             return None
         for bed_region in self.regions:
             if bed_region == self.best_region:
                 return_regions[bed_region] = bed_region
             elif self.is_subsumed(bed_region, self.best_region):
-                # Subsumed region
+                # Subsumed region in the best region
                 return_regions[bed_region] = None
             elif self.are_overlapping(bed_region, self.best_region):
                 # Overlaps with best region, but isn't subsumed
@@ -101,36 +101,41 @@ class OverlapRegion:
                 return_regions[bed_region] = bed_region
 
         # Double check if any still overlap. If so, adjust smaller of the regions.
-        sorted_regions = sorted([(b, a) for b, a in return_regions.items() if a is not None], key=lambda x: x[1])
-        i, j = 0, 1
-        while j < len(sorted_regions):
-            region1_before, region2_before = sorted_regions[i][0], sorted_regions[j][0]
-            region1_after, region2_after = sorted_regions[i][1], sorted_regions[j][1]
-            if region1_after is None or region2_after is None:
+        existing_overlaps = True
+        while existing_overlaps:
+            sorted_regions = sorted([(b, a) for b, a in return_regions.items() if a is not None], key=lambda x: x[1])
+            i, j = 0, 1
+            existing_overlaps = False
+            while j < len(sorted_regions):
+                region1_before, region2_before = sorted_regions[i][0], sorted_regions[j][0]
+                region1_after, region2_after = sorted_regions[i][1], sorted_regions[j][1]
+                if region1_after is None or region2_after is None:
+                    i += 1
+                    j += 1
+                    continue
+                if self.are_overlapping(region1_after, region2_after):
+                    existing_overlaps = True
+                    if self.is_subsumed(region1_after, region2_after):
+                        # Region 1 is subsumed in region 2 - Remove region 1
+                        return_regions[region1_before] = None
+                    elif self.is_subsumed(region2_after, region1_after):
+                        # Region 2 is subsumed in region 1 - Remove region 2
+                        return_regions[region2_before] = None
+                        continue
+                    elif (region1_after.end - region1_after.start) > (region2_after.end - region2_after.start):
+                        # Adjust region 2 start
+                        return_regions[region2_before] = Bed(contig=region2_after.contig, start=region1_after.end + 1,
+                                                             end=region2_after.end)
+                    elif (region1_after.end - region1_after.start) <= (region2_after.end - region2_after.start):
+                        # Adjust region 1 end
+                        return_regions[region1_before] = Bed(contig=region1_after.contig, start=region1_after.start,
+                                                             end=region2_after.start - 1)
+                    else:
+                        print("Unexpected case!")
+                        print(region1_before, region2_before, region1_after, region1_after)
+
                 i += 1
                 j += 1
-                continue
-            if self.are_overlapping(region1_after, region2_after):
-                if self.is_subsumed(region1_after, region2_after):
-                    # Region 1 is subsumed in region 2 - Remove region 1
-                    return_regions[region1_before] = None
-                elif self.is_subsumed(region2_after, region1_after):
-                    return_regions[region2_before] = None
-                    j += 1 # since removed region 2, don't increment i to catch potential overlaps
-                    continue
-                elif (region1_after.end - region1_after.start) > (region2_after.end - region2_after.start):
-                    # Adjust region 2 start
-                    return_regions[region2_before] = Bed(contig=region2_after.contig, start=region1_after.end + 1,
-                                                         end=region2_after.end)
-                elif (region1_after.end - region1_after.start) <= (region2_after.end - region2_after.start):
-                    # Adjust region 1 end
-                    return_regions[region1_before] = Bed(contig=region1_after.contig, start=region1_after.start,
-                                                         end=region2_after.start - 1)
-                else:
-                    print("Unexpected case!")
-                    print(region1_before, region2_before, region1_after, region1_after)
-            i += 1
-            j += 1
 
         return return_regions
 

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -121,7 +121,9 @@ class OverlapRegion:
                     # Adjust region 1 end
                     return_regions[region1_before] = Bed(contig=region1_after.contig, start=region1_after.start,
                                                          end=region2_after.start - 1)
-
+                else:
+                    print("Unexpected case!")
+                    print(region1_before, region2_before, region1_after, region1_after)
             i += 1
 
         return return_regions

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -103,9 +103,7 @@ class OverlapRegion:
         # Double check if any still overlap. If so, adjust smaller of the regions.
         sorted_regions = sorted([(b, a) for b, a in return_regions.items() if a is not None], key=lambda x: x[1])
         i, j = 0, 1
-        print(sorted_regions[0][0], sorted_regions)
         while j < len(sorted_regions):
-        #for i in range(0, len(sorted_regions)-1):
             region1_before, region2_before = sorted_regions[i][0], sorted_regions[j][0]
             region1_after, region2_after = sorted_regions[i][1], sorted_regions[j][1]
             if region1_after is None or region2_after is None:

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -736,8 +736,8 @@ class Ntjoin:
         new_path = []
         for path_node in path:
             if path_node.contig in intersecting_regions:
-                if path_node.start != intersecting_regions[path_node.contig].start or \
-                    path_node.end != intersecting_regions[path_node.contig].end:
+                if path_node.start != intersecting_regions[path_node.contig].best_region.start or \
+                    path_node.end != intersecting_regions[path_node.contig].best_region.end:
                     continue
             new_path.append(path_node)
 

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -100,7 +100,7 @@ class OverlapRegion:
             else:
                 return_regions[bed_region] = bed_region
 
-        # Double check if any still overlap. If so, adjust smaller of the regions.
+        # Double check if any still overlaps. If so, adjust smaller of the overlapping regions.
         existing_overlaps = True
         while existing_overlaps:
             sorted_regions = sorted([(b, a) for b, a in return_regions.items() if a is not None], key=lambda x: x[1])
@@ -121,7 +121,6 @@ class OverlapRegion:
                     elif self.is_subsumed(region2_after, region1_after):
                         # Region 2 is subsumed in region 1 - Remove region 2
                         return_regions[region2_before] = None
-                        continue
                     elif (region1_after.end - region1_after.start) > (region2_after.end - region2_after.start):
                         # Adjust region 2 start
                         return_regions[region2_before] = Bed(contig=region2_after.contig, start=region1_after.end + 1,
@@ -551,7 +550,7 @@ class Ntjoin:
 
     @staticmethod
     def tally_incorporated_segments(incorporated_list, path):
-        "Keep track of extents incorporated into path"
+        "Keep track of contig segments incorporated into path"
         if len(path) < 2:
             return
         for path_node in path:
@@ -623,7 +622,7 @@ class Ntjoin:
         return False
 
     def adjust_paths(self, paths, scaffolds, incorporated_segments):
-        "Given the found paths, removes duplicate regions to avoid cutting sequences"
+        "Given the found paths, removes duplicate regions to avoid cutting sequences (no_cut=True option)"
         contig_regions = {}  # contig_id -> [list of PathNode]
         for path in paths:
             for node in path:

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -384,10 +384,12 @@ class Ntjoin:
         return gap_size
 
     @staticmethod
-    def is_new_region_overlapping(start, end, incorporated_segments_ctg):
+    def is_new_region_overlapping(start, end, node_i, node_j, incorporated_segments_ctg):
         "Checks if the specified region overlaps any existing regions in incorporated segments"
         for segment in incorporated_segments_ctg:
-            if start <= segment.end and segment.start <= end:
+            if start <= segment.end and segment.start <= end and \
+                    (segment.start != node_i.start and segment.end != node_i.end) and \
+                    (segment.start != node_j.start and segment.end != node_j.end):
                 return True
         return False
 
@@ -400,7 +402,7 @@ class Ntjoin:
         for node_i, node_j in zip(path, path[1:]):
             if node_i.contig == node_j.contig:
                 if node_i.ori == "+" and node_j.ori == "+" and node_i.end <= node_j.start:
-                    if self.is_new_region_overlapping(node_i.start, node_j.end,
+                    if self.is_new_region_overlapping(node_i.start, node_j.end, node_i, node_j,
                                                       incorporated_segments[node_i.contig]):
                         return_path.append(node_j)
                         continue
@@ -410,7 +412,7 @@ class Ntjoin:
                                                                     start=node_i.start,
                                                                     end=node_j.end))
                 elif node_i.ori == "-" and node_j.ori == "-" and node_i.start >= node_j.end:
-                    if self.is_new_region_overlapping(node_j.start, node_i.end,
+                    if self.is_new_region_overlapping(node_j.start, node_i.end, node_i, node_j,
                                                       incorporated_segments[node_i.contig]):
                         return_path.append(node_j)
                         continue

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -103,11 +103,14 @@ class OverlapRegion:
         # Double check if any still overlap. If so, adjust smaller of the regions.
         sorted_regions = sorted([(b, a) for b, a in return_regions.items() if a is not None], key=lambda x: x[1])
         i, j = 0, 1
+        print(sorted_regions[0].contig, sorted_regions)
         while j < len(sorted_regions)-1:
         #for i in range(0, len(sorted_regions)-1):
             region1_before, region2_before = sorted_regions[i][0], sorted_regions[j][0]
             region1_after, region2_after = sorted_regions[i][1], sorted_regions[j][1]
             if region1_after is None or region2_after is None:
+                i += 1
+                j += 1
                 continue
             if self.are_overlapping(region1_after, region2_after):
                 if self.is_subsumed(region1_after, region2_after):

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -83,7 +83,6 @@ class OverlapRegion:
         if not self.regions or self.best_region is None:
             return None
         for bed_region in self.regions:
-            new_region = bed_region
             if bed_region == self.best_region:
                 return_regions[bed_region] = bed_region
             elif self.is_subsumed(bed_region, self.best_region):
@@ -92,9 +91,11 @@ class OverlapRegion:
             elif self.are_overlapping(bed_region, self.best_region):
                 # Overlaps with best region, but isn't subsumed
                 if bed_region.start <= self.best_region.start:
-                    new_region.end = self.best_region.start - 1
+                    new_region = Bed(contig=bed_region.contig, start=bed_region.start,
+                                     end=self.best_region.start - 1)
                 elif bed_region.end >= self.best_region.end:
-                    new_region.start = self.best_region.end + 1
+                    new_region = Bed(contig=bed_region.contig, start=self.best_region.end + 1,
+                                     end=bed_region.end)
                 return_regions[bed_region] = new_region
             else:
                 return_regions[bed_region] = bed_region

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -102,9 +102,11 @@ class OverlapRegion:
 
         # Double check if any still overlap. If so, adjust smaller of the regions.
         sorted_regions = sorted([(b, a) for b, a in return_regions.items() if a is not None], key=lambda x: x[1])
-        for i in range(0, len(sorted_regions)-1):
-            region1_before, region2_before = sorted_regions[i][0], sorted_regions[i+1][0]
-            region1_after, region2_after = sorted_regions[i][1], sorted_regions[i+1][1]
+        i, j = 0, 1
+        while j < len(sorted_regions)-1:
+        #for i in range(0, len(sorted_regions)-1):
+            region1_before, region2_before = sorted_regions[i][0], sorted_regions[j][0]
+            region1_after, region2_after = sorted_regions[i][1], sorted_regions[j][1]
             if region1_after is None or region2_after is None:
                 continue
             if self.are_overlapping(region1_after, region2_after):
@@ -113,6 +115,8 @@ class OverlapRegion:
                     return_regions[region1_before] = None
                 elif self.is_subsumed(region2_after, region1_after):
                     return_regions[region2_before] = None
+                    j += 1 # since removed region 2, don't increment i to catch potential overlaps
+                    continue
                 elif (region1_after.end - region1_after.start) > (region2_after.end - region2_after.start):
                     # Adjust region 2 start
                     return_regions[region2_before] = Bed(contig=region2_after.contig, start=region1_after.end + 1,
@@ -125,6 +129,7 @@ class OverlapRegion:
                     print("Unexpected case!")
                     print(region1_before, region2_before, region1_after, region1_after)
             i += 1
+            j += 1
 
         return return_regions
 


### PR DESCRIPTION
Fixes for edge cases where sequences in the target assembly could be duplicated in the output scaffolds.
