### PR TITLE
Fix compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=-O3 -Wall -Werror -Wno-unknown-pragmas -std=c++11 -pthread -Ibtllib/include
+CXXFLAGS=-O3 -Wall -Wno-unknown-pragmas -std=c++11 -pthread -Ibtllib/include
 
 all: indexlr
 


### PR DESCRIPTION
The usage of `-Werror` breaks compilation:

    $BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++ -O3 -Wall -Werror -Wno-unknown-pragmas -std=c++11 -pthread -Ibtllib/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem $PREFIX/include -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,-rpath,$PREFIX/lib -Wl,-rpath-link,$PREFIX/lib -L$PREFIX/lib  indexlr.cpp   -o indexlr
    indexlr.cpp: In lambda function:
    indexlr.cpp:298:11: error: ignoring return value of 'size_t fwrite(const void*, size_t, size_t, FILE*)', declared with attribute warn_unused_result [-Werror=unused-result]
         fwrite(to_write.c_str(), 1, to_write.size(), out);
         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    cc1plus: all warnings being treated as errors
    make: *** [indexlr] Error 1

Xref: https://github.com/bioconda/bioconda-recipes/pull/25361