### PR TITLE
Update btllib dependency info

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ curl -L --output ntJoin-1.1.1.tar.gz https://github.com/bcgsc/ntJoin/releases/do
 * [bedtools v2.29.2+](https://bedtools.readthedocs.io/en/latest/)
 * [samtools](https://github.com/samtools/samtools)
 * [zlib](https://www.zlib.net/)
-* [btllib](https://github.com/bcgsc/btllib)
+* [btllib](https://github.com/bcgsc/btllib) v1.4.10 or lower
 
 Python dependencies can be installed with:
 ```sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-igraph
 pybedtools
 pymannkendall
-btllib
+btllib <=1.4.10


### PR DESCRIPTION
* Use btllib v1.4.10 and lower pending python wrapper fix in latest version