### PR TITLE
Bugfix for cases where there are no output paths, and overlap=True

### DIFF
--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -722,6 +722,8 @@ class Ntjoin:
         mx_info = defaultdict(dict)  # path_index -> mx -> pos
         mxs = {}  # path_index -> [mx]
         cur_path_index = 0
+        if not paths:
+            return # If list of paths is empty
         cur_valid_segments = {f"{node.contig}_{node.start}_{node.end}"
                                   for node in paths[cur_path_index]}
         with btllib.Indexlr(fasta_filename, self.args.overlap_k, self.args.overlap_w,


### PR DESCRIPTION
* If there are no paths and overlap=True is set, an error would be thrown when `adjust_for_trimming` is run
  * Check for empty list of paths upfront to avoid this