### PR TITLE
Fix for circular references

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
 
   - script: |
       source activate ntjoin_CI
-      conda install --yes --quiet --name ntjoin_CI -c conda-forge -c bioconda python=3.9 mamba
+      conda install --yes --quiet --name ntjoin_CI -c conda-forge -c bioconda python mamba
       mamba install --yes --quiet -c conda-forge -c bioconda pylint samtools python-igraph pybedtools pymannkendall btllib
     displayName: Install Anaconda packages
   - script: |

--- a/bin/ntjoin.py
+++ b/bin/ntjoin.py
@@ -9,8 +9,10 @@ import multiprocessing
 import sys
 import warnings
 import ntjoin_utils
+from collections import namedtuple
 warnings.simplefilter(action='ignore', category=RuntimeWarning)
 
+VertexPosition = namedtuple('VertexPosition', ['vertex_index', 'position'])
 
 class Ntjoin:
     "ntJoin: Scaffolding and analyzing synteny in assemblies using reference assemblies and minimizer graphs"
@@ -110,6 +112,27 @@ class Ntjoin:
                 return False
         return True
 
+    def check_circularity(self, graph):
+        "Check if the graph is circular"
+        if all(u.degree() == 2 for u in graph.vs()): # Is circular graph, find reasonable source/target nodes
+            highest_wt_asm, _ = sorted(list(self.weights.items()),
+                                    key=lambda x: x[1], reverse=True)[0]
+            min_pos_vertex = None
+            for vertex in graph.vs():
+                vertex_name = ntjoin_utils.vertex_name(graph, vertex.index)
+                if min_pos_vertex is None or \
+                    self.list_mx_info[highest_wt_asm][vertex_name][1] < min_pos_vertex.position:
+                    min_pos_vertex = VertexPosition(vertex.index,
+                                                    self.list_mx_info[highest_wt_asm][vertex_name][1])
+            neighbours = graph.neighbors(min_pos_vertex.vertex_index)
+            highest_pos_neighbour = sorted(neighbours,
+                                           key=lambda x: self.list_mx_info[highest_wt_asm][
+                                               ntjoin_utils.vertex_name(graph, x)][1],
+                                           reverse=True)[0]
+            # Break circularity for sake of scaffolding
+            graph.delete_edges(graph.get_eid(min_pos_vertex.vertex_index, highest_pos_neighbour))
+            return min_pos_vertex.vertex_index, highest_pos_neighbour
+        return []
 
     def find_paths_process(self, component):
         "Find paths given a component of the graph"
@@ -124,6 +147,8 @@ class Ntjoin:
         for subcomponent in component_graph.components():
             subcomponent_graph = component_graph.subgraph(subcomponent)
             source_nodes = [node.index for node in subcomponent_graph.vs() if node.degree() == 1]
+            if not source_nodes:
+                source_nodes = self.check_circularity(subcomponent_graph)
             if len(source_nodes) == 2:
                 source, target = self.determine_source_vertex(source_nodes, subcomponent_graph)
                 path = subcomponent_graph.get_shortest_paths(source, target)[0]

--- a/bin/ntjoin.py
+++ b/bin/ntjoin.py
@@ -8,8 +8,8 @@ import datetime
 import multiprocessing
 import sys
 import warnings
-import ntjoin_utils
 from collections import namedtuple
+import ntjoin_utils
 warnings.simplefilter(action='ignore', category=RuntimeWarning)
 
 VertexPosition = namedtuple('VertexPosition', ['vertex_index', 'position'])

--- a/bin/ntjoin_assemble.py
+++ b/bin/ntjoin_assemble.py
@@ -771,7 +771,6 @@ class NtjoinScaffolder(ntjoin.Ntjoin):
 
         # Find the paths through the graph
         paths = self.find_paths()
-
         # Format the paths to PathNodes, tally incorporated segments
         paths, incorporated_segments = self.format_adjust_paths(paths)
 


### PR DESCRIPTION
* I found that in some cases, using a circular reference can lead to no scaffolds being scaffolded
* With some investigation, it was due to the checking for start/end nodes in the linear graph search step
  * We relied on looking for nodes with a degree of 1 at either end of the linear segment, but it is possible for a perfect circular path to be a valid graph segment, meaning that all nodes would have a degree of 2
* With this fix, identify these edge cases, and break the graph at the minimizer node with the smallest position in the reference
  * This allows scaffolding to take place properly 