### PR TITLE
Update README.md, azure-pipelines.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ ntJoin assemble target=my_scaffolds.fa target_weight=1 reference_config=config_f
 
 * We recommend setting the reference weight(s) to be higher than the target weight
 * If you are using a reference-grade assembly as the reference, set `n=2`, otherwise use the default `n=1`
+* When using `no_cut=True`, if you find that the output genome size is inflated, it is likely due to large gaps being incorporated into your output assembly. You can set the maximum gap size (`G`) to offset this.
 
 ### Overlap feature
 * As of version 1.1.0, ntJoin can detect and trim overlaps between joined sequences. This feature is controlled by the `overlap` parameter, and is on `overlap=True` by default. To turn this behaviour off, specify `overlap=False`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,11 +67,3 @@ jobs:
       cd tests
       pytest -vs ntjoin_test.py
     displayName: Run pytests
-  - script: |
-      source activate ntjoin_CI
-      python3 -c 'import pybedtools; print(pybedtools.__version__)'
-      mamba install --yes --quiet -c conda-forge -c bioconda pybedtools=0.9.0
-      python3 -c 'import pybedtools; print(pybedtools.__version__)'
-      cd tests
-      pytest -vs ntjoin_test.py
-    displayName: Run pytests with lower pybedtools version


### PR DESCRIPTION
* Add note about potentially high numbers of "Ns" in scaffolded assemblies for runs when `no_cut=True` is used
* Remove extra pybedtools test from macOS - redundant, and the lower versions are not compatible with python 3.12+