### PR TITLE
Install conda using miniforge for macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,15 +50,22 @@ jobs:
   pool:
     vmImage: macOS-latest
   steps:
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
 
   - script: conda create --yes --quiet --name ntjoin_CI
     displayName: Create Anaconda environment
 
   - script: |
       source activate ntjoin_CI
-      conda install --yes --quiet --name ntjoin_CI -c conda-forge -c bioconda python mamba
       mamba install --yes --quiet -c conda-forge -c bioconda pylint samtools python-igraph pybedtools pymannkendall btllib
     displayName: Install Anaconda packages
   - script: |


### PR DESCRIPTION
* Recently, macOS-latest VM was updated to use macOS-14
  * This VM no longer has conda installed by default
* Workaround is to install miniforge as part of the CI
  * This already has mamba, which is a side benefit