### PR TITLE
Add new overlap filter to avoid potentially erroneous overlap trims

### DIFF
--- a/bin/ntjoin_overlap.py
+++ b/bin/ntjoin_overlap.py
@@ -98,9 +98,6 @@ def merge_overlapping(list_mxs, list_mx_info, source, target, nodes):
     target_trim_amount = target_cut
     if source_trim_amount > nodes[target].get_aligned_length() or \
             target_trim_amount > nodes[source].get_aligned_length():
-        print(f"NOTE: Skipping overlap trim between {nodes[source].contig} and "
-              f"{nodes[target].contig} - inferred overlap length exceeds a sequence length "
-              f"(source_trim={source_trim_amount}, target_trim={target_trim_amount})")
         return False
 
     nodes[source].end_adjust = source_cut

--- a/bin/ntjoin_overlap.py
+++ b/bin/ntjoin_overlap.py
@@ -92,6 +92,16 @@ def merge_overlapping(list_mxs, list_mx_info, source, target, nodes):
         return False
     if target_cut >= nodes[target].get_end_adjusted_coordinate():
         return False
+    
+    # If the overlap length is greater than either of the incident segments, abort trim
+    source_trim_amount = nodes[source].get_aligned_length() - source_cut
+    target_trim_amount = target_cut
+    if source_trim_amount > nodes[target].get_aligned_length() or \
+            target_trim_amount > nodes[source].get_aligned_length():
+        print(f"NOTE: Skipping overlap trim between {nodes[source].contig} and "
+              f"{nodes[target].contig} - inferred overlap length exceeds a sequence length "
+              f"(source_trim={source_trim_amount}, target_trim={target_trim_amount})")
+        return False
 
     nodes[source].end_adjust = source_cut
     nodes[target].start_adjust = target_cut


### PR DESCRIPTION
* Do not do trim if the overlap length in one sequence is greater than the other sequence in the join